### PR TITLE
ArrayOutOfBounds exception when there aren't any configs

### DIFF
--- a/src/main/java/flightsim/simconnect/config/ConfigurationManager.java
+++ b/src/main/java/flightsim/simconnect/config/ConfigurationManager.java
@@ -88,8 +88,7 @@ public class ConfigurationManager {
 	 */
 	public static Configuration getConfiguration(int number) throws ConfigurationNotFoundException { 
 		if (!inited) readConfiguration();
-		if (number > configs.size()) throw new ConfigurationNotFoundException(number);
-		if (configs.size() == 0) throw new ConfigurationNotFoundException(number);
+		if (configs.size() == 0 || number > configs.size()) throw new ConfigurationNotFoundException(number);
 		return configs.get(number);
 	}
 }

--- a/src/main/java/flightsim/simconnect/config/ConfigurationManager.java
+++ b/src/main/java/flightsim/simconnect/config/ConfigurationManager.java
@@ -89,8 +89,7 @@ public class ConfigurationManager {
 	public static Configuration getConfiguration(int number) throws ConfigurationNotFoundException { 
 		if (!inited) readConfiguration();
 		if (number > configs.size()) throw new ConfigurationNotFoundException(number);
-		Configuration cfg = configs.get(number);
-		if (cfg == null) throw new ConfigurationNotFoundException(number);
-		return cfg;
+		if (configs.size() == 0) throw new ConfigurationNotFoundException(number);
+		return configs.get(number);
 	}
 }


### PR DESCRIPTION
When there aren't any configs an ArrayOutOfBounds exception will be thrown instead of an ConfigurationNotFoundException. Causing problems when using a SimConnect constructor that should autodetect the configurations and there are none. I fixed it by throwing the ConfigurationNotFoundException when the Configuration vector is empty.

I am aware this library comes from another website. If fixes aren't accepted by github, where else can I submit it?